### PR TITLE
Rebalance EBF Voltages and Durations

### DIFF
--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEIO.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEIO.java
@@ -51,7 +51,7 @@ public class LabsEIO {
                         .temp(1350, GasTier.LOW)
                         .blastStats(VA[HV], 400))
                 .components(EnergeticAlloy, 1, EnderPearl, 1)
-                .cableProperties(V[HV], 1, 0, true)
+                .cableProperties(V[MV], 1, 0, true)
                 .build();
 
         PulsatingIron = new Material.Builder(32014, makeLabsName("pulsating_iron"))

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEIO.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEIO.java
@@ -1,10 +1,11 @@
 package com.nomiceu.nomilabs.gregtech.material.registry.register;
 
 import gregtech.api.unification.material.Material;
-import gregtech.api.unification.material.properties.BlastProperty;
+import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 import gregtech.api.unification.material.properties.ToolProperty;
 
 import static com.nomiceu.nomilabs.util.LabsNames.makeLabsName;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
@@ -26,7 +27,7 @@ public class LabsEIO {
                 .color(0xf7b29b).iconSet(METALLIC)
                 .flags(GENERATE_PLATE, GENERATE_GEAR)
                 .components(Iron, 1, Redstone, 1)
-                .cableProperties(32, 1, 0, true)
+                .cableProperties(V[LV], 1, 0, true)
                 .build();
 
         EnergeticAlloy = new Material.Builder(32012, makeLabsName("energetic_alloy"))
@@ -34,9 +35,11 @@ public class LabsEIO {
                 .liquid()
                 .color(0xffb545).iconSet(SHINY)
                 .flags(GENERATE_PLATE, GENERATE_GEAR)
-                .blast(builder -> builder.temp(1250, BlastProperty.GasTier.LOW).blastStats(120, 400))
+                .blast(builder -> builder
+                        .temp(1250, GasTier.LOW)
+                        .blastStats(VA[MV], 400))
                 .components(Gold, 2, Redstone, 1, Glowstone, 1)
-                .cableProperties(128, 1, 0, true)
+                .cableProperties(V[MV], 1, 0, true)
                 .build();
 
         VibrantAlloy = new Material.Builder(32013, makeLabsName("vibrant_alloy"))
@@ -44,9 +47,11 @@ public class LabsEIO {
                 .liquid()
                 .color(0xa4ff70).iconSet(SHINY)
                 .flags(GENERATE_PLATE, GENERATE_GEAR, GENERATE_ROD, GENERATE_BOLT_SCREW)
-                .blast(builder -> builder.temp(1350, BlastProperty.GasTier.LOW).blastStats(120, 600))
+                .blast(builder -> builder
+                        .temp(1350, GasTier.LOW)
+                        .blastStats(VA[HV], 400))
                 .components(EnergeticAlloy, 1, EnderPearl, 1)
-                .cableProperties(512, 1, 0, true)
+                .cableProperties(V[HV], 1, 0, true)
                 .build();
 
         PulsatingIron = new Material.Builder(32014, makeLabsName("pulsating_iron"))
@@ -55,7 +60,7 @@ public class LabsEIO {
                 .color(0x6ae26e).iconSet(SHINY)
                 .flags(GENERATE_PLATE, GENERATE_GEAR)
                 .components(Iron, 1)
-                .cableProperties(8, 1, 0, true)
+                .cableProperties(V[ULV], 1, 0, true)
                 .build();
 
         ElectricalSteel = new Material.Builder(32015, makeLabsName("electrical_steel"))
@@ -79,8 +84,8 @@ public class LabsEIO {
                 .liquid()
                 .color(0xd6d980).iconSet(METALLIC)
                 .flags(GENERATE_PLATE, GENERATE_GEAR)
-                .toolStats(new ToolProperty(4.0f, 3.5f, 1024, 3))
-                .cableProperties(2048, 1, 0, true)
+                .toolStats(ToolProperty.Builder.of(4.0f, 3.5f, 1024, 3).build())
+                .cableProperties(V[EV], 1, 0, true)
                 .build();
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsElements.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsElements.java
@@ -3,7 +3,7 @@ package com.nomiceu.nomilabs.gregtech.material.registry.register;
 import gregtech.api.unification.Element;
 import gregtech.api.unification.Elements;
 import gregtech.api.unification.material.Material;
-import gregtech.api.unification.material.properties.BlastProperty;
+import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 
 import static com.nomiceu.nomilabs.gregtech.material.registry.LabsMaterials.*;
 import static com.nomiceu.nomilabs.util.LabsNames.makeLabsName;
@@ -22,7 +22,7 @@ public class LabsElements {
                 .ingot().liquid().ore()
                 .element(Dc)
                 .color(0xbe49ed).iconSet(METALLIC)
-                .blast(6800, BlastProperty.GasTier.HIGHER)
+                .blast(6800, GasTier.HIGHER)
                 .cableProperties(V[UV], 1, 0, true)
                 .flags(GENERATE_PLATE, GENERATE_ROD, GENERATE_GEAR, GENERATE_DENSE)
                 .build();
@@ -46,7 +46,10 @@ public class LabsElements {
                 .ingot().liquid()
                 .color(0xff00ff).iconSet(BRIGHT)
                 .flags(GENERATE_PLATE, GENERATE_DENSE)
-                .blast(10800)
+                .blast(builder -> builder
+                        .temp(10800, GasTier.HIGHEST)
+                        .blastStats(VA[ZPM], 1800)
+                        .vacuumStats(VA[LuV], 600))
                 .build();
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsElements.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsElements.java
@@ -7,6 +7,7 @@ import gregtech.api.unification.material.properties.BlastProperty;
 
 import static com.nomiceu.nomilabs.gregtech.material.registry.LabsMaterials.*;
 import static com.nomiceu.nomilabs.util.LabsNames.makeLabsName;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
 
@@ -22,7 +23,7 @@ public class LabsElements {
                 .element(Dc)
                 .color(0xbe49ed).iconSet(METALLIC)
                 .blast(6800, BlastProperty.GasTier.HIGHER)
-                .cableProperties(524288, 1, 0, true)
+                .cableProperties(V[UV], 1, 0, true)
                 .flags(GENERATE_PLATE, GENERATE_ROD, GENERATE_GEAR, GENERATE_DENSE)
                 .build();
 
@@ -37,7 +38,7 @@ public class LabsElements {
                 .ingot().liquid()
                 .element(Nm)
                 .color(0x84053e).iconSet(SHINY)
-                .cableProperties(2147483647, 64, 0, true)
+                .cableProperties(V[MAX], 64, 0, true)
                 .build();
 
         Taranium = new Material.Builder(32109, makeLabsName("taranium")) // Hardmode Material

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEndgame.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEndgame.java
@@ -3,6 +3,7 @@ package com.nomiceu.nomilabs.gregtech.material.registry.register;
 import gregtech.api.unification.material.Material;
 
 import static com.nomiceu.nomilabs.util.LabsNames.makeLabsName;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
@@ -19,7 +20,7 @@ public class LabsEndgame {
         DraconicSuperconductor = new Material.Builder(32028, makeLabsName("draconic_superconductor"))
                 .ingot()
                 .color(0xf5f0f4).iconSet(SHINY)
-                .cableProperties(2147483647, 4, 0, true)
+                .cableProperties(V[MAX], 4, 0, true)
                 .build();
 
         KaptonK = new Material.Builder(32050, makeLabsName("kapton_k")) // Hardmode Material

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsPlatLine.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsPlatLine.java
@@ -29,9 +29,7 @@ public class LabsPlatLine {
                 .color(0xfef0c2).iconSet(METALLIC)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Nitrogen, 2, Hydrogen, 8, Platinum, 1, Chlorine, 6)
-                .build();
-
-        AmmoniumHexachloroplatinate.setFormula("(NH4)2PtCl6", true);
+                .build().setFormula("(NH4)2PtCl6", true);
 
         ChloroplatinicAcid = new Material.Builder(32070, makeLabsName("chloroplatinic_acid"))
                 .liquid()
@@ -75,9 +73,7 @@ public class LabsPlatLine {
                 .color(0x776649).iconSet(FINE)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Rhodium, 1, Nitrogen, 3, Oxygen, 9)
-                .build();
-
-        RhodiumNitrate.setFormula("Rh(NO3)3", true);
+                .build().setFormula("Rh(NO3)3", true);
 
         SodiumRuthenate = new Material.Builder(32077, makeLabsName("sodium_ruthenate")) // Hardmode Material
                 .dust()
@@ -104,9 +100,7 @@ public class LabsPlatLine {
                 .color(0x644629).iconSet(ROUGH)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Nitrogen, 2, Hydrogen, 8, Iridium, 1, Chlorine, 6)
-                .build();
-
-        AmmoniumHexachloroiridiate.setFormula("(NH4)2IrCl6", true);
+                .build().setFormula("(NH4)2IrCl6", true);
 
         PlatinumGroupResidue = new Material.Builder(32081, makeLabsName("platinum_group_residue")) // Hardmode Material
                 .dust()
@@ -162,9 +156,7 @@ public class LabsPlatLine {
                 .color(0x848484).iconSet(SHINY)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Salt, 2, Rhodium, 2, Chlorine, 6)
-                .build();
-
-        RhodiumSalt.setFormula("(NaCl)2(RhCl3)2", true);
+                .build().setFormula("(NaCl)2(RhCl3)2", true);
 
         AcidicIridiumDioxideSolution = new Material.Builder(32089, makeLabsName("acidic_iridium_dioxide_solution"))
                 .liquid()
@@ -185,18 +177,14 @@ public class LabsPlatLine {
                 .color(0xffaaaa)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 2, Hydrogen, 4, Oxygen, 2)
-                .build();
-
-        MethylFormate.setFormula("HCOOCH3", true);
+                .build().setFormula("HCOOCH3", true);
 
         FormicAcid = new Material.Builder(32092, makeLabsName("formic_acid"))
                 .liquid()
                 .color(0xffffc5)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 1, Hydrogen, 2, Oxygen, 2)
-                .build();
-
-        FormicAcid.setFormula("HCOOH", true);
+                .build().setFormula("HCOOH", true);
 
         SodiumMethoxide = new Material.Builder(32093, makeLabsName("sodium_methoxide")) // Hardmode Material
                 .dust()

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsTaraniumLine.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsTaraniumLine.java
@@ -64,9 +64,7 @@ public class LabsTaraniumLine {
                 .liquid()
                 .color(0xa567db)
                 .components(Xenon, 1, Water, 1, Oxygen, 5, HydrogenPeroxide, 1)
-                .build();
-
-        XenicAcid.setFormula("H2XeO4", true);
+                .build().setFormula("H2XeO4", true);
 
         DustyHelium = new Material.Builder(32103, makeLabsName("dusty_helium"))
                 .gas()

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsThermal.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsThermal.java
@@ -1,9 +1,10 @@
 package com.nomiceu.nomilabs.gregtech.material.registry.register;
 
 import gregtech.api.unification.material.Material;
-import gregtech.api.unification.material.properties.BlastProperty;
+import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 
 import static com.nomiceu.nomilabs.util.LabsNames.makeLabsName;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
@@ -35,10 +36,13 @@ public class LabsThermal {
                 .ingot()
                 .liquid()
                 .color(0xff7f0f).iconSet(SHINY)
-                .blast(builder -> builder.temp(4000, BlastProperty.GasTier.MID).blastStats(120, 12800))
+                .blast(builder -> builder
+                        .temp(4000, GasTier.MID)
+                        .blastStats(VA[IV], 1400)
+                        .vacuumStats(VA[HV], 500))
                 .flags(GENERATE_PLATE, GENERATE_DENSE, GENERATE_ROD, GENERATE_GEAR)
                 .components(AnnealedCopper, 4, Ardite, 2, RedAlloy, 2)
-                .cableProperties(32768, 1, 0, true)
+                .cableProperties(V[LuV], 1, 0, true)
                 .build();
 
         Lumium = new Material.Builder(32017, makeLabsName("lumium"))
@@ -46,9 +50,12 @@ public class LabsThermal {
                 .liquid()
                 .color(0xf6ff99).iconSet(BRIGHT)
                 .flags(GENERATE_PLATE, GENERATE_GEAR, GENERATE_FINE_WIRE)
-                .blast(builder -> builder.temp(4500, BlastProperty.GasTier.MID).blastStats(120, 14400))
+                .blast(builder -> builder
+                        .temp(4500, GasTier.MID)
+                        .blastStats(VA[IV], 1600)
+                        .vacuumStats(VA[HV], 600))
                 .components(TinAlloy, 4, SterlingSilver, 2)
-                .cableProperties(8192, 1, 0, true)
+                .cableProperties(V[IV], 1, 0, true)
                 .build();
 
         Enderium = new Material.Builder(32018, makeLabsName("enderium"))
@@ -56,9 +63,12 @@ public class LabsThermal {
                 .liquid()
                 .color(0x1f6b62).iconSet(SHINY)
                 .flags(GENERATE_PLATE, GENERATE_GEAR, GENERATE_FINE_WIRE)
-                .blast(builder -> builder.temp(6400, BlastProperty.GasTier.HIGHEST).blastStats(120, 20800))
+                .blast(builder -> builder
+                        .temp(6400, GasTier.HIGHEST)
+                        .blastStats(VA[LuV], 1200)
+                        .vacuumStats(VA[EV], 400))
                 .components(Lead, 4, Platinum, 2, BlueSteel, 1, Osmium, 1)
-                .cableProperties(131072, 1, 0, true)
+                .cableProperties(V[ZPM], 1, 0, true)
                 .build();
 
         ElectrumFlux = new Material.Builder(32019, makeLabsName("electrum_flux"))


### PR DESCRIPTION
Signalum: MV -> IV
Lumium: MV -> IV
Enderium: MV -> LuV
Taranium: MV -> ZPM, and gave it a gas tier (HIGHEST, so Krypton)

Durations adjusted accordingly, as are vacuum freezer recipes.

I also adjusted some usages of magic numbers to use GT constants (such as VA[xx] for EBF EU/t, and V[xx] for wire voltage) as well as some other cleanups

**Draconium and Fluxed Electrum need more work, as these recipes are special so blast property may need to be handled differently**