### PR TITLE
Add Laurite (RuS₂) and Cuprorhodsite (CuFeRh₄S₈) ores

### DIFF
--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/LabsMaterials.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/LabsMaterials.java
@@ -129,6 +129,8 @@ public class LabsMaterials {
     public static Material Snowchestite; // ID: 60; HM only
     public static Material Darmstadtite; // ID: 110
     public static Material Dulysite; // ID: 111; HM only
+    public static Material Laurite; // ID: 116
+    public static Material Cuprorhodsite; // ID: 117
 
     /**
      * Thermal Materials

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsMicroverse.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsMicroverse.java
@@ -65,5 +65,19 @@ public class LabsMicroverse {
                 .components(Duranium, 1, Chlorine, 3)
                 .addOreByproducts(Sphalerite, Duranium, Europium)
                 .build();
+
+        Laurite = new Material.Builder(116, makeLabsName("laurite"))
+                .gem().ore()
+                .color(0x6f2c23).iconSet(DIAMOND)
+                .components(Ruthenium, 1, Sulfur, 2)
+                .addOreByproducts(Pyrite, Ruthenium, Rhodium)
+                .build();
+
+        Cuprorhodsite = new Material.Builder(117, makeLabsName("cuprorhodsite"))
+                .dust().ore()
+                .color(0xc1aa82).iconSet(BRIGHT)
+                .components(Copper, 1, Iron, 1, Rhodium, 4, Sulfur, 8)
+                .addOreByproducts(Chalcocite, Platinum, Ruthenium)
+                .build();
     }
 }

--- a/src/main/resources/assets/nomilabs/lang/en_us.lang
+++ b/src/main/resources/assets/nomilabs/lang/en_us.lang
@@ -259,6 +259,8 @@ nomilabs.material.butanol=Butanol
 nomilabs.material.phosphorus_trichloride=Phosphorus Trichloride
 nomilabs.material.phosphoryl_chloride=Phosphoryl Chloride
 nomilabs.material.tributyl_phosphate=Tributyl Phosphate
+nomilabs.material.laurite=Laurite
+nomilabs.material.cuprorhodsite=Cuprorhodsite
 
 item.nomilabs.nomicoin.name=Nomipenny [1]
 item.nomilabs.nomicoin5.name=Nominickel [5]


### PR DESCRIPTION
This PR adds Laurite (RuS₂) and Cuprorhodsite (CuFeRh₄S₈) ore materials to address https://github.com/GregTechCEu/GregTech/pull/2185 and Nomi-CEu/Nomi-CEu#621.

To be added to T3 Microminer