### PR TITLE
Superconductor Materials and Amperage Balancing

### DIFF
--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEIO.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEIO.java
@@ -38,7 +38,7 @@ public class LabsEIO {
                 .flags(GENERATE_PLATE, GENERATE_DOUBLE_PLATE, GENERATE_GEAR)
                 .blast(builder -> builder
                         .temp(1250, GasTier.LOW)
-                        .blastStats(VA[MV], 400))
+                        .blastStats(VA[MV], 300))
                 .components(Gold, 2, Redstone, 1, Glowstone, 1)
                 .cableProperties(V[MV], 1, 0, true)
                 .build();
@@ -50,7 +50,7 @@ public class LabsEIO {
                 .flags(GENERATE_PLATE, GENERATE_DOUBLE_PLATE, GENERATE_GEAR, GENERATE_ROD, GENERATE_BOLT_SCREW)
                 .blast(builder -> builder
                         .temp(1350, GasTier.LOW)
-                        .blastStats(VA[MV], 400))
+                        .blastStats(VA[MV], 350))
                 .components(EnergeticAlloy, 1, EnderPearl, 1)
                 .cableProperties(V[HV], 1, 0, true)
                 .build();
@@ -81,12 +81,15 @@ public class LabsEIO {
                 .build();
 
         EndSteel = new Material.Builder(25, makeLabsName("end_steel"))
-                .ingot()
-                .liquid()
+                .ingot().liquid()
                 .color(0xd6d980).iconSet(METALLIC)
+                .blast(builder -> builder
+                        .temp(1400, GasTier.LOW)
+                        .blastStats(VHA[EV], 400))
                 .flags(GENERATE_PLATE, GENERATE_GEAR)
                 .toolStats(ToolProperty.Builder.of(4.0f, 3.5f, 1024, 3).build())
-                .cableProperties(V[EV], 1, 0, true)
+                .cableProperties(V[EV], 2, 0, true)
+                .components(VibrantAlloy, 1, DarkSteel, 1, Endstone, 1)
                 .build();
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsElements.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsElements.java
@@ -27,7 +27,7 @@ public class LabsElements {
                         .temp(6800, GasTier.HIGHER)
                         .blastStats(VA[LuV], 1800)
                         .vacuumStats(VA[EV], 600))
-                .cableProperties(V[UV], 1, 0, true)
+                .cableProperties(V[UV], 8, 0, true)
                 .flags(GENERATE_PLATE, GENERATE_DOUBLE_PLATE, GENERATE_ROD, GENERATE_GEAR, GENERATE_DENSE)
                 .build();
 

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEndgame.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsEndgame.java
@@ -3,7 +3,6 @@ package com.nomiceu.nomilabs.gregtech.material.registry.register;
 import static com.nomiceu.nomilabs.gregtech.material.registry.LabsMaterials.*;
 import static com.nomiceu.nomilabs.util.LabsNames.makeLabsName;
 import static gregtech.api.GTValues.*;
-import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
 
@@ -21,16 +20,14 @@ public class LabsEndgame {
         DraconicSuperconductor = new Material.Builder(28, makeLabsName("draconic_superconductor"))
                 .ingot()
                 .color(0xf5f0f4).iconSet(SHINY)
-                .cableProperties(V[MAX], 4, 0, true)
+                .cableProperties(V[MAX], 16, 0, true)
                 .build();
 
         KaptonK = new Material.Builder(50, makeLabsName("kapton_k")) // Hardmode Material
                 .ingot().liquid()
                 .color(0xffce52).iconSet(DULL)
                 .flags(GENERATE_PLATE, DISABLE_DECOMPOSITION)
-                .components(Carbon, 22, Hydrogen, 10, Nitrogen, 2, Oxygen, 5)
+                .components(Oxydianiline, 3, PyromelliticDianhydride, 2)
                 .build();
-
-        KaptonK.setFormula("C6H2((CO)2N)2C6H4OC6H4", true);
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsThermal.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsThermal.java
@@ -33,32 +33,32 @@ public class LabsThermal {
                 .components(Ardite, 4, Cobalt, 4, Mana, 1)
                 .build();
 
-        Signalum = new Material.Builder(10, makeLabsName("signalum"))
-                .ingot()
-                .liquid()
-                .color(0xff7f0f).iconSet(SHINY)
-                .blast(builder -> builder
-                        .temp(4000, GasTier.MID)
-                        .blastStats(VA[IV], 1400)
-                        .vacuumStats(VA[HV], 500))
-                .flags(GENERATE_PLATE, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROD, GENERATE_GEAR)
-                .components(AnnealedCopper, 4, Ardite, 2, RedAlloy, 2)
-                .cableProperties(V[LuV], 1, 0, true)
-                .itemPipeProperties(512, 64)
-                .build();
-
         Lumium = new Material.Builder(17, makeLabsName("lumium"))
                 .ingot()
                 .liquid()
                 .color(0xf6ff99).iconSet(BRIGHT)
                 .flags(GENERATE_PLATE, GENERATE_DOUBLE_PLATE, GENERATE_GEAR, GENERATE_FINE_WIRE)
                 .blast(builder -> builder
-                        .temp(4500, GasTier.MID)
+                        .temp(4000, GasTier.MID)
+                        .blastStats(VHA[IV], 800)
+                        .vacuumStats(VHA[HV], 300))
+                .components(TinAlloy, 4, SterlingSilver, 2)
+                .cableProperties(V[IV], 4, 0, true)
+                .fluidPipeProperties(4500, 256, true, true, true, false)
+                .build();
+
+        Signalum = new Material.Builder(10, makeLabsName("signalum"))
+                .ingot()
+                .liquid()
+                .color(0xff7f0f).iconSet(SHINY)
+                .blast(builder -> builder
+                        .temp(4500, GasTier.HIGHER)
                         .blastStats(VA[IV], 1600)
                         .vacuumStats(VA[HV], 600))
-                .components(TinAlloy, 4, SterlingSilver, 2)
-                .cableProperties(V[IV], 1, 0, true)
-                .fluidPipeProperties(4500, 256, true, true, true, false)
+                .flags(GENERATE_PLATE, GENERATE_DOUBLE_PLATE, GENERATE_DENSE, GENERATE_ROD, GENERATE_GEAR)
+                .components(AnnealedCopper, 4, Ardite, 2, RedAlloy, 2)
+                .cableProperties(V[LuV], 4, 0, true)
+                .itemPipeProperties(512, 64)
                 .build();
 
         Enderium = new Material.Builder(18, makeLabsName("enderium"))
@@ -71,7 +71,7 @@ public class LabsThermal {
                         .blastStats(VA[LuV], 1600)
                         .vacuumStats(VA[EV], 600))
                 .components(Lead, 4, Platinum, 2, BlueSteel, 1, Osmium, 1)
-                .cableProperties(V[ZPM], 1, 0, true)
+                .cableProperties(V[ZPM], 8, 0, true)
                 .build();
 
         ElectrumFlux = new Material.Builder(19, makeLabsName("electrum_flux"))


### PR DESCRIPTION
This PR rebalances superconductor materials, and their amperage, to make them more competitive against GregTech's superconductors.

It also changes end steel to require EBF, and mixer (although recipe for that would come in Nomi-CEu, as well as the removal of current alloy smelter recipes), to make Energetic and Vibrant Alloy cables more competitive in MV and HV. End Steel will require Vibrant Alloy to make.

This PR also rebalances lumium and signalum, so that signalum takes a longer duration, and requires a higher tier gas to boost, making lumium the preferred superconductor before signalum, further fixing non-linear progression issues.

Further rebalancing may take place following this PR, on the `dev/1.8` branch.

