### PR TITLE
Improve TOPAddons fluid rendering

### DIFF
--- a/src/main/java/com/nomiceu/nomilabs/mixin/topaddons/ElementTankGaugeMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/topaddons/ElementTankGaugeMixin.java
@@ -5,6 +5,11 @@ import static io.github.drmanganese.topaddons.elements.ElementRenderHelper.drawS
 import java.util.Objects;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,11 +21,9 @@ import com.nomiceu.nomilabs.integration.top.LabsFluidNameElement;
 import com.nomiceu.nomilabs.util.LabsTranslate;
 
 import gregtech.api.util.TextFormattingUtil;
+import gregtech.client.utils.RenderUtil;
 import io.github.drmanganese.topaddons.elements.ElementTankGauge;
-import mcjty.theoneprobe.api.IProgressStyle;
-import mcjty.theoneprobe.apiimpl.client.ElementProgressRender;
 import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
-import mcjty.theoneprobe.apiimpl.styles.ProgressStyle;
 import mcjty.theoneprobe.rendering.RenderHelper;
 
 /**
@@ -69,24 +72,58 @@ public class ElementTankGaugeMixin {
     @Unique
     private String labs$capacityInfo = null;
 
+    @Unique
+    private TextureAtlasSprite labs$sprite = null;
+
     @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
     private void newRenderLogic(int x, int y, CallbackInfo ci) {
         boolean hasFluid = capacity > 0 && amount > 0;
         boolean expand = sneaking && hasFluid;
-
         int barHeight = expand ? 12 : 8;
-        IProgressStyle style = new ProgressStyle()
-                .borderColor(hasFluid ? color2 : 0xff969696)
-                .filledColor(color1)
-                .alternateFilledColor(color1)
-                .backgroundColor(0x44969696)
-                .showText(false);
 
-        ElementProgressRender.render(style, amount, capacity, x, y, 100, barHeight);
+        // Update sprite if needed
+        if (hasFluid && labs$sprite == null) {
+            Fluid fluid = FluidRegistry.getFluid(fluidName);
+            if (fluid != null) {
+                labs$sprite = Minecraft.getMinecraft().getTextureMapBlocks()
+                        .getAtlasSprite(fluid.getStill().toString());
+            }
+        }
+
+        // Box
+        int borderColor = hasFluid ? color2 : 0xff969696;
+        RenderHelper.drawThickBeveledBox(x, y, x + 100, y + barHeight, 1, borderColor, borderColor, 0x44969696);
+
+        // Render fluid
+        if (hasFluid && labs$sprite != null) {
+            GlStateManager.enableBlend();
+            Minecraft.getMinecraft().renderEngine.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+
+            RenderUtil.setGlColorFromInt(color1, 0xFF);
+
+            final int scaledAmount = (int) ((long) amount * 98 / capacity);
+
+            final int xTileCount = scaledAmount / 16;
+            final int xRemainder = scaledAmount - xTileCount * 16;
+
+            for (int xTile = 0; xTile <= xTileCount; xTile++) {
+                int width = xTile == xTileCount ? xRemainder : 16;
+                int fluidX = x + 1 + (xTile + 1) * 16 - 16;
+                if (width > 0) {
+                    int maskTop = 16 - barHeight + 2;
+                    int maskRight = 16 - width;
+
+                    RenderUtil.drawFluidTexture(fluidX, y - 16 + barHeight - 1, labs$sprite, maskTop, maskRight,
+                            0.0);
+                }
+            }
+
+            GlStateManager.disableBlend();
+        }
 
         for (int i = 1; i < 10; i++) {
             RenderHelper.drawVerticalLine(x + i * 10, y + 1, y + (i == 5 ? barHeight - 1 : barHeight / 2),
-                    hasFluid ? color2 : 0xff767676);
+                    borderColor);
         }
 
         if (expand) {


### PR DESCRIPTION
This PR changes the way fluids are rendered with TOPAddons by editing ElementTankGaugeMixin.
Instead of simply drawing a colored box, the fluid's texture is rendered
![screenshot1](https://github.com/user-attachments/assets/cf79064a-b171-44cd-8965-d72d4dde0341)
![screenshot2](https://github.com/user-attachments/assets/7974c8bb-12a1-44b5-b651-e7c7d7f67d48)
