### PR TITLE
Fix Incorrect Xenic Acid Breakdown

### DIFF
--- a/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsTaraniumLine.java
+++ b/src/main/java/com/nomiceu/nomilabs/gregtech/material/registry/register/LabsTaraniumLine.java
@@ -65,7 +65,7 @@ public class LabsTaraniumLine {
         XenicAcid = new Material.Builder(102, makeLabsName("xenic_acid"))
                 .liquid()
                 .color(0xa567db)
-                .components(Xenon, 1, Water, 1, Oxygen, 5, HydrogenPeroxide, 1)
+                .components(Xenon, 1, Water, 1, Oxygen, 3)
                 .build().setFormula("H2XeO4", true);
 
         DustyHelium = new Material.Builder(103, makeLabsName("dusty_helium"))


### PR DESCRIPTION
Changes Xenic acid breakdown to be stoichiometrically correct. Recipe otherwise gave twice as much oxygen and hydrogen as it should. This change is consistent with acid electrolysis yielding oxygen gas, not H2O2 I made this change in the taranium line in Monifactory. Tell me if change is unwanted.