### PR TITLE
Allow for Dummy Muffler Hatches

### DIFF
--- a/src/main/java/com/nomiceu/nomilabs/config/LabsConfig.java
+++ b/src/main/java/com/nomiceu/nomilabs/config/LabsConfig.java
@@ -339,7 +339,7 @@ public class LabsConfig {
         @Config.Comment({
                 "Enable Dummy Muffler hatches.",
                 "Makes muffler hatches not produce ash anymore.",
-                "This improves performance when high parallel multiblocks with mufflers trying to calculate the ash.",
+                "This improves performance when multiblocks try to calculate ash output. This is especially useful for high parallels.",
                 "[default: false]"
         })
         @Config.LangKey("config.nomilabs.content.gt_content.dummy_muffler_hatches")

--- a/src/main/java/com/nomiceu/nomilabs/config/LabsConfig.java
+++ b/src/main/java/com/nomiceu/nomilabs/config/LabsConfig.java
@@ -339,12 +339,12 @@ public class LabsConfig {
         @Config.Comment({
                 "Enable Dummy Muffler hatches.",
                 "Makes muffler hatches not produce ash anymore.",
-                "This fixes potential lag when there is a high parallel on a multiblocks trying to calculate the ash.",
-                "[default: true]"
+                "This improves performance when high parallel multiblocks with mufflers trying to calculate the ash.",
+                "[default: false]"
         })
         @Config.LangKey("config.nomilabs.content.gt_content.dummy_muffler_hatches")
         @Config.RequiresMcRestart
-        public boolean enableDummyMufflers = true;
+        public boolean enableDummyMufflers = false;
 
         @Config.Comment("AE2 Terminal Options")
         @Config.LangKey("config.nomilabs.mod_integration.ae2_terminal")

--- a/src/main/java/com/nomiceu/nomilabs/config/LabsConfig.java
+++ b/src/main/java/com/nomiceu/nomilabs/config/LabsConfig.java
@@ -336,6 +336,16 @@ public class LabsConfig {
         @Config.LangKey("config.nomilabs.mod_integration.disable_armor_plus_frag_drops")
         public boolean disableArmorPlusFragDrops = false;
 
+        @Config.Comment({
+                "Enable Dummy Muffler hatches.",
+                "Makes muffler hatches not produce ash anymore.",
+                "This fixes potential lag when there is a high parallel on a multiblocks trying to calculate the ash.",
+                "[default: true]"
+        })
+        @Config.LangKey("config.nomilabs.content.gt_content.dummy_muffler_hatches")
+        @Config.RequiresMcRestart
+        public boolean enableDummyMufflers = true;
+
         @Config.Comment("AE2 Terminal Options")
         @Config.LangKey("config.nomilabs.mod_integration.ae2_terminal")
         @Config.Name("ae2 terminal options")

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
@@ -17,25 +17,31 @@ import gregtech.api.gui.widgets.SimpleTextWidget;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMufflerHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 
+/**
+ * Change the muffler GUI to clarify that it is a dummy muffler, and will not generate any ashes.
+ */
 @Mixin(value = MetaTileEntityMufflerHatch.class, remap = false)
 public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMultiblockPart {
 
-    // The mixin must provide a constructor matching the superclass.
-    protected MetaTileEntityMufflerHatchMixin(ResourceLocation metaTileEntityId, int tier) {
+    /**
+     * Mandatory Ignored Constructor
+     */
+    private MetaTileEntityMufflerHatchMixin(ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, tier);
     }
 
     @Inject(method = "createUI(Lnet/minecraft/entity/player/EntityPlayer;)Lgregtech/api/gui/ModularUI;",
             at = @At("HEAD"),
             cancellable = true)
-    private void onCreateUI(EntityPlayer entityPlayer, CallbackInfoReturnable<ModularUI> cir) {
-        if (LabsConfig.modIntegration.enableDummyMufflers) {
-            ModularUI.Builder builder = ModularUI.builder(GuiTextures.BORDERED_BACKGROUND, 200, 100)
-                    .widget(new ImageWidget(92, 16, 16, 16, GuiTextures.INFO_ICON))
-                    .widget(
-                            new SimpleTextWidget(100, 60, "gregtech.gui.muffler.notify_change", 0x555555, () -> "")
-                                    .setWidth(180));
-            cir.setReturnValue(builder.build(getHolder(), entityPlayer));
+    private void setMufflerUI(EntityPlayer entityPlayer, CallbackInfoReturnable<ModularUI> cir) {
+        if (!LabsConfig.modIntegration.enableDummyMufflers) {
+            return;
         }
+        ModularUI.Builder builder = ModularUI.builder(GuiTextures.BORDERED_BACKGROUND, 200, 100)
+                .widget(new ImageWidget(92, 16, 16, 16, GuiTextures.INFO_ICON))
+                .widget(
+                        new SimpleTextWidget(100, 60, "nomilabs.gui.dummy_muffler", 0x555555, () -> "")
+                                .setWidth(180));
+        cir.setReturnValue(builder.build(getHolder(), entityPlayer));
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
@@ -1,18 +1,20 @@
 package com.nomiceu.nomilabs.mixin.gregtech;
 
+import com.nomiceu.nomilabs.config.LabsConfig;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 
 import gregtech.api.gui.GuiTextures;
-import gregtech.api.gui.IUIHolder;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.SimpleTextWidget;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMufflerHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = MetaTileEntityMufflerHatch.class, remap = false)
 public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMultiblockPart {
@@ -22,19 +24,17 @@ public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMult
         super(metaTileEntityId, tier);
     }
 
-    /**
-     * @reason Overwrite createUI to display a custom message.
-     * @author D-Alessian
-     */
-    @Overwrite
-    protected ModularUI createUI(EntityPlayer entityPlayer) {
-        // Directly call getHolder() inherited from MetaTileEntityMultiblockPart
-        IUIHolder holder = this.getHolder();
-        ModularUI.Builder builder = ModularUI.builder(GuiTextures.BORDERED_BACKGROUND, 200, 100)
-                .widget(new ImageWidget(92, 16, 16, 16, GuiTextures.INFO_ICON))
-                .widget(
-                        new SimpleTextWidget(100, 60, "gregtech.gui.muffler.notify_change", 0x555555, () -> "")
-                                .setWidth(180));
-        return builder.build(holder, entityPlayer);
+    @Inject(method = "createUI(Lnet/minecraft/entity/player/EntityPlayer;)Lgregtech/api/gui/ModularUI;",
+            at = @At("HEAD"), cancellable = true)
+    private void onCreateUI(EntityPlayer entityPlayer, CallbackInfoReturnable<ModularUI> cir) {
+        if (LabsConfig.modIntegration.enableDummyMufflers) {
+            ModularUI.Builder builder = ModularUI.builder(GuiTextures.BORDERED_BACKGROUND, 200, 100)
+                    .widget(new ImageWidget(92, 16, 16, 16, GuiTextures.INFO_ICON))
+                    .widget(
+                            new SimpleTextWidget(100, 60, "gregtech.gui.muffler.notify_change", 0x555555, () -> "")
+                                    .setWidth(180)
+                    );
+            cir.setReturnValue(builder.build(getHolder(), entityPlayer));
+        }
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
@@ -1,10 +1,14 @@
 package com.nomiceu.nomilabs.mixin.gregtech;
 
-import com.nomiceu.nomilabs.config.LabsConfig;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.nomiceu.nomilabs.config.LabsConfig;
 
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -12,9 +16,6 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.SimpleTextWidget;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMufflerHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = MetaTileEntityMufflerHatch.class, remap = false)
 public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMultiblockPart {
@@ -25,15 +26,15 @@ public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMult
     }
 
     @Inject(method = "createUI(Lnet/minecraft/entity/player/EntityPlayer;)Lgregtech/api/gui/ModularUI;",
-            at = @At("HEAD"), cancellable = true)
+            at = @At("HEAD"),
+            cancellable = true)
     private void onCreateUI(EntityPlayer entityPlayer, CallbackInfoReturnable<ModularUI> cir) {
         if (LabsConfig.modIntegration.enableDummyMufflers) {
             ModularUI.Builder builder = ModularUI.builder(GuiTextures.BORDERED_BACKGROUND, 200, 100)
                     .widget(new ImageWidget(92, 16, 16, 16, GuiTextures.INFO_ICON))
                     .widget(
                             new SimpleTextWidget(100, 60, "gregtech.gui.muffler.notify_change", 0x555555, () -> "")
-                                    .setWidth(180)
-                    );
+                                    .setWidth(180));
             cir.setReturnValue(builder.build(getHolder(), entityPlayer));
         }
     }

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
@@ -1,16 +1,18 @@
 package com.nomiceu.nomilabs.mixin.gregtech;
 
-import gregtech.api.gui.widgets.ImageWidget;
-import gregtech.api.gui.widgets.SimpleTextWidget;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
-import gregtech.api.gui.ModularUI;
+
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.IUIHolder;
-import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
+import gregtech.api.gui.ModularUI;
+import gregtech.api.gui.widgets.ImageWidget;
+import gregtech.api.gui.widgets.SimpleTextWidget;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMufflerHatch;
-import net.minecraft.entity.player.EntityPlayer;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 
 @Mixin(value = MetaTileEntityMufflerHatch.class, remap = false)
 public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMultiblockPart {
@@ -32,8 +34,7 @@ public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMult
                 .widget(new ImageWidget(92, 16, 16, 16, GuiTextures.INFO_ICON))
                 .widget(
                         new SimpleTextWidget(100, 60, "gregtech.gui.muffler.notify_change", 0x555555, () -> "")
-                                .setWidth(180)
-                );
+                                .setWidth(180));
         return builder.build(holder, entityPlayer);
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MetaTileEntityMufflerHatchMixin.java
@@ -1,0 +1,39 @@
+package com.nomiceu.nomilabs.mixin.gregtech;
+
+import gregtech.api.gui.widgets.ImageWidget;
+import gregtech.api.gui.widgets.SimpleTextWidget;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import gregtech.api.gui.ModularUI;
+import gregtech.api.gui.GuiTextures;
+import gregtech.api.gui.IUIHolder;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMufflerHatch;
+import net.minecraft.entity.player.EntityPlayer;
+
+@Mixin(value = MetaTileEntityMufflerHatch.class, remap = false)
+public abstract class MetaTileEntityMufflerHatchMixin extends MetaTileEntityMultiblockPart {
+
+    // The mixin must provide a constructor matching the superclass.
+    protected MetaTileEntityMufflerHatchMixin(ResourceLocation metaTileEntityId, int tier) {
+        super(metaTileEntityId, tier);
+    }
+
+    /**
+     * @reason Overwrite createUI to display a custom message.
+     * @author D-Alessian
+     */
+    @Overwrite
+    protected ModularUI createUI(EntityPlayer entityPlayer) {
+        // Directly call getHolder() inherited from MetaTileEntityMultiblockPart
+        IUIHolder holder = this.getHolder();
+        ModularUI.Builder builder = ModularUI.builder(GuiTextures.BORDERED_BACKGROUND, 200, 100)
+                .widget(new ImageWidget(92, 16, 16, 16, GuiTextures.INFO_ICON))
+                .widget(
+                        new SimpleTextWidget(100, 60, "gregtech.gui.muffler.notify_change", 0x555555, () -> "")
+                                .setWidth(180)
+                );
+        return builder.build(holder, entityPlayer);
+    }
+}

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
@@ -1,14 +1,13 @@
 package com.nomiceu.nomilabs.mixin.gregtech;
 
-import com.nomiceu.nomilabs.config.LabsConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import com.nomiceu.nomilabs.config.LabsConfig;
 import com.nomiceu.nomilabs.gregtech.mixinhelper.IRefreshBeforeConsumption;
 
 import gregtech.api.capability.impl.AbstractRecipeLogic;
@@ -30,7 +29,8 @@ public abstract class MultiblockRecipeLogicMixin extends AbstractRecipeLogic {
         super(tileEntity, recipeMap);
     }
 
-    @Shadow protected abstract void performMufflerOperations();
+    @Shadow
+    protected abstract void performMufflerOperations();
 
     @Inject(method = "prepareRecipeDistinct", at = @At("HEAD"))
     private void refresh(Recipe recipe, CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
@@ -1,6 +1,9 @@
 package com.nomiceu.nomilabs.mixin.gregtech;
 
+import com.nomiceu.nomilabs.config.LabsConfig;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -27,6 +30,8 @@ public abstract class MultiblockRecipeLogicMixin extends AbstractRecipeLogic {
         super(tileEntity, recipeMap);
     }
 
+    @Shadow protected abstract void performMufflerOperations();
+
     @Inject(method = "prepareRecipeDistinct", at = @At("HEAD"))
     private void refresh(Recipe recipe, CallbackInfoReturnable<Boolean> cir) {
         ((IRefreshBeforeConsumption) metaTileEntity).labs$refreshBeforeConsumption();
@@ -41,12 +46,13 @@ public abstract class MultiblockRecipeLogicMixin extends AbstractRecipeLogic {
     /**
      * Remove Muffler Logic
      */
-    @Redirect(
-              method = "completeRecipe()V",
-              at = @At(
-                       value = "INVOKE",
-                       target = "Lgregtech/api/capability/impl/MultiblockRecipeLogic;performMufflerOperations()V"))
-    private void removeMufflerMechanic(MultiblockRecipeLogic instance) {
-        // Do nothing
+    @Overwrite
+    protected void completeRecipe() {
+        // Call the superclass implementation.
+        super.completeRecipe();
+        // Conditionally perform muffler operations.
+        if (!LabsConfig.modIntegration.enableDummyMufflers) {
+            performMufflerOperations();
+        }
     }
 }

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
@@ -18,7 +18,7 @@ import gregtech.api.recipes.RecipeMap;
 /**
  * Part of <a href="https://github.com/GregTechCEu/GregTech/pull/2646">GTCEu #2646</a> impl.
  * <p>
- * Also intercepts and cancels the muffler hatches recipe logic from running.
+ * Also cancels the muffler hatch operations.
  */
 @Mixin(value = MultiblockRecipeLogic.class, remap = false)
 public abstract class MultiblockRecipeLogicMixin extends AbstractRecipeLogic {

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
@@ -42,15 +42,11 @@ public abstract class MultiblockRecipeLogicMixin extends AbstractRecipeLogic {
      * Remove Muffler Logic
      */
     @Redirect(
-            method = "completeRecipe()V",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lgregtech/api/capability/impl/MultiblockRecipeLogic;performMufflerOperations()V"
-            )
-    )
+              method = "completeRecipe()V",
+              at = @At(
+                       value = "INVOKE",
+                       target = "Lgregtech/api/capability/impl/MultiblockRecipeLogic;performMufflerOperations()V"))
     private void removeMufflerMechanic(MultiblockRecipeLogic instance) {
         // Do nothing
     }
 }
-
-

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
@@ -3,6 +3,7 @@ package com.nomiceu.nomilabs.mixin.gregtech;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.nomiceu.nomilabs.gregtech.mixinhelper.IRefreshBeforeConsumption;
@@ -36,4 +37,20 @@ public abstract class MultiblockRecipeLogicMixin extends AbstractRecipeLogic {
         ((IRefreshBeforeConsumption) metaTileEntity).labs$refreshBeforeConsumption();
         return super.prepareRecipe(recipe);
     }
+
+    /**
+     * Remove Muffler Logic
+     */
+    @Redirect(
+            method = "completeRecipe()V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lgregtech/api/capability/impl/MultiblockRecipeLogic;performMufflerOperations()V"
+            )
+    )
+    private void removeMufflerMechanic(MultiblockRecipeLogic instance) {
+        // Do nothing
+    }
 }
+
+

--- a/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
+++ b/src/main/java/com/nomiceu/nomilabs/mixin/gregtech/MultiblockRecipeLogicMixin.java
@@ -44,7 +44,10 @@ public abstract class MultiblockRecipeLogicMixin extends AbstractRecipeLogic {
     }
 
     /**
-     * Remove Muffler Logic
+     * @reason Conditionally skip the muffler operations based on the LabsConfig setting.
+     *         When dummy mufflers are enabled, we don't call performMufflerOperations().
+     *         This is because mufflers cause a lot of lag, for little to no benefit.
+     * @author D-Alessian
      */
     @Overwrite
     protected void completeRecipe() {

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2,4 +2,4 @@
 metaitem.bronze_cell.name=%s Bronze Cell
 
 #-----------------GUI-----------------#
-gregtech.gui.muffler.notify_change=Muffler hatches no longer generate ashes in Nomi-CEu due to lag concerns.
+gregtech.gui.muffler.notify_change=Muffler hatches no longer generate ashes in Nomi-CEu due to lag concerns. You can enable this again in config.

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1,2 +1,5 @@
 #-----------------Meta Items-----------------#
 metaitem.bronze_cell.name=%s Bronze Cell
+
+#-----------------GUI-----------------#
+gregtech.gui.muffler.notify_change=Muffler hatches no longer generate ashes in Nomi-CEu due to lag concerns.

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1,5 +1,2 @@
 #-----------------Meta Items-----------------#
 metaitem.bronze_cell.name=%s Bronze Cell
-
-#-----------------GUI-----------------#
-gregtech.gui.muffler.notify_change=Muffler hatches no longer generate ashes in Nomi-CEu due to lag concerns. You can enable this again in config.

--- a/src/main/resources/assets/nomilabs/lang/en_us.lang
+++ b/src/main/resources/assets/nomilabs/lang/en_us.lang
@@ -51,6 +51,7 @@ config.nomilabs.mod_integration.jei_ing_empty_line=Add JEI Ingredient Tooltip Em
 config.nomilabs.mod_integration.bqu_fluid_task_fixes=Enable BQu Fluid Task Fixes
 config.nomilabs.mod_integration.screwdrive_aa_relays=Allow GT Screwdrivers for AA Laser Relays
 config.nomilabs.mod_integration.disable_armor_plus_frag_drops=Disable Armor Plus Fragment Drops
+config.nomilabs.mod_integration.dummy_muffler_hatches="Enable Dummy Muffler Hatches"
 
 config.nomilabs.mod_integration.effortlessbuilding=Effortless Building Integration Settings
 config.nomilabs.mod_integration.effortlessbuilding.enable=Enable Effortless Building Integration

--- a/src/main/resources/assets/nomilabs/lang/en_us.lang
+++ b/src/main/resources/assets/nomilabs/lang/en_us.lang
@@ -230,6 +230,8 @@ gui.advanced_memory_card.mode.add_as_output=Current Mode: Add as Output
 nomilabs.gui.advanced_memory_card.mode.add_output.desc.1=Before binding, the §aselected P2P§7 has its connections removed.
 nomilabs.gui.advanced_memory_card.mode.add_output.desc.2=The §aselected P2P§7 is set as an §6output§7, with the §bbind target's§7 frequency.
 
+nomilabs.gui.dummy_muffler=Muffler hatches no longer generate ashes to improve performance. You can enable this again in config.
+
 # Custom Fluids
 fluid.uranium233=Uranium 233
 fluid.plutonium2=Plutonium

--- a/src/main/resources/mixins.nomilabs.gregtech.json
+++ b/src/main/resources/mixins.nomilabs.gregtech.json
@@ -24,6 +24,7 @@
     "MetaItemsMixin",
     "MetaTileEntityMEStockingBusMixin",
     "MetaTileEntityMEStockingHatchMixin",
+    "MetaTileEntityMufflerHatchMixin",
     "MetaTileEntityProcessingArrayMixin",
     "MetaValueItemMixin",
     "MinerLogicMixin",


### PR DESCRIPTION
### What this PR adds:
- Removes the ability of mufflers to generate ashes, this makes every multiblock that needs mufflers much more lag free
- Adds a GUI warning to mufflers to explain this to avoid confused players
- A config option to turn this back on if need be since this may not please all players
### Potential issues:
- I'm really not sure about the placement of :
  * The lang entry for the GUI, and it's naming
  * The placement of the config
  
  So please give feedback on where I could place this and if there's better naming for it.
- This would completely break once 2.9 rolls out, but I'm already going to work on a 2.9 compatible version of this code.

The code has been tested, works without issues and eliminates a LOT of lag on some machines as expected. The effect will be most prominent on high parallel multiblocks like:
- Multi smelter (laggiest multiblock in every world I've had before this PR)
- GCYMs with mufflers (RHF, Fractionnary distil, Brewery, etc.)
- Addons like ZBGT that allow huge parallel numbers.

And here is a preview of how the GUI looks in game.
<img width="853" alt="Screenshot 2025-03-06 at 14 13 31" src="https://github.com/user-attachments/assets/724d6407-153f-40c6-8bde-22078e2830eb" />

(Yes I did PR this to the correct place this time)

  